### PR TITLE
reduce log verbosity: argocd-notifications warn level + loki gateway …

### DIFF
--- a/apps/argocd/values.yaml
+++ b/apps/argocd/values.yaml
@@ -37,6 +37,7 @@ argo-cd:
       renewBefore: ""
       secretName: argocd-server-tls
   notifications:
+    logLevel: warn
     secret:
       # -- Whether helm chart creates notifications controller secret
       create: false

--- a/apps/loki/values.yaml
+++ b/apps/loki/values.yaml
@@ -40,6 +40,8 @@ loki:
       requests:
         cpu: 100m
         memory: 256Mi
+  gateway:
+    verboseLogging: false
   backend:
     replicas: 0
   read:


### PR DESCRIPTION
…access log off

argocd-notifications-controller was logging every trigger evaluation for every app every ~15s at info level, generating ~5MB/day on the 47MB zram /var/log. loki-gateway nginx was logging every promtail push and k8s health probe, also ~5MB/day. Both were filling up orange2/orange3 /var/log partitions.