### PR TITLE
gateway-api-demo: add demo app for Gateway API testing

### DIFF
--- a/apps/gateway-api-demo/application.yaml
+++ b/apps/gateway-api-demo/application.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gateway-api-demo
+  namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.slack: argo
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: argo
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: argo
+    notifications.argoproj.io/subscribe.on-sync-running.slack: argo
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: argo
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: argo
+spec:
+  destination:
+    namespace: gw-api-demo
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: apps/gateway-api-demo
+    repoURL: https://github.com/germanium-git/argocd
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/apps/gateway-api-demo/deployment.yaml
+++ b/apps/gateway-api-demo/deployment.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  namespace: gw-api-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami:v1.10.3
+          ports:
+            - containerPort: 80

--- a/apps/gateway-api-demo/httproute-http.yaml
+++ b/apps/gateway-api-demo/httproute-http.yaml
@@ -1,0 +1,22 @@
+---
+# HTTP → HTTPS redirect (demonstrates RequestRedirect filter)
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: whoami-http-redirect
+  namespace: gw-api-demo
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "172.31.1.34"
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+  hostnames:
+    - "gwapidemo.germanium.cz"
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/apps/gateway-api-demo/httproute-https.yaml
+++ b/apps/gateway-api-demo/httproute-https.yaml
@@ -1,0 +1,46 @@
+---
+# HTTPS routing with TLS termination and path rewrite demo
+#
+# Routes:
+#   gwapidemo.germanium.cz/api/*  →  rewritten to /*  →  whoami  (URLRewrite filter)
+#   gwapidemo.germanium.cz/*      →  direct            →  whoami
+#
+# The whoami app echoes request details, so the path rewrite is clearly visible:
+# hitting /api/foo arrives at whoami as /foo.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: whoami-https
+  namespace: gw-api-demo
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "172.31.1.34"
+spec:
+  parentRefs:
+    - name: traefik-gateway-tls
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - "gwapidemo.germanium.cz"
+  rules:
+    # Path rewrite: strip /api prefix before forwarding
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        - name: whoami
+          port: 80
+    # Default: route everything else directly
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: whoami
+          port: 80

--- a/apps/gateway-api-demo/namespace.yaml
+++ b/apps/gateway-api-demo/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gw-api-demo

--- a/apps/gateway-api-demo/service.yaml
+++ b/apps/gateway-api-demo/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: gw-api-demo
+spec:
+  selector:
+    app: whoami
+  ports:
+    - port: 80
+      targetPort: 80


### PR DESCRIPTION
Demonstrates Gateway API features in namespace gw-api-demo using traefik/whoami (arm64-compatible, echoes request details to make routing/rewrite effects visible).

Resources:
- Deployment + Service: traefik/whoami:v1.10.3, 2 replicas
- httproute-http.yaml: HTTP → HTTPS redirect via RequestRedirect filter
- httproute-https.yaml: HTTPS routing via traefik-gateway-tls with two rules: /api/* → rewritten to /* (URLRewrite / ReplacePrefixMatch)
    /*     → direct to whoami
- external-dns annotation on HTTPRoutes targets 172.31.1.34 (Traefik LB IP)
  because Traefik v3.0 does not populate Gateway status.addresses

Apply application.yaml manually, then sync in ArgoCD.