### PR TITLE
external-dns: annotate Gateways with target IP 172.31.1.34

### DIFF
--- a/apps/gateway-api-demo/httproute-http.yaml
+++ b/apps/gateway-api-demo/httproute-http.yaml
@@ -5,8 +5,6 @@ kind: HTTPRoute
 metadata:
   name: whoami-http-redirect
   namespace: gw-api-demo
-  annotations:
-    external-dns.alpha.kubernetes.io/target: "172.31.1.34"
 spec:
   parentRefs:
     - name: traefik-gateway

--- a/apps/gateway-api-demo/httproute-https.yaml
+++ b/apps/gateway-api-demo/httproute-https.yaml
@@ -12,8 +12,6 @@ kind: HTTPRoute
 metadata:
   name: whoami-https
   namespace: gw-api-demo
-  annotations:
-    external-dns.alpha.kubernetes.io/target: "172.31.1.34"
 spec:
   parentRefs:
     - name: traefik-gateway-tls

--- a/apps/traefik/addons/gateway-tls.yaml
+++ b/apps/traefik/addons/gateway-tls.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: traefik-gateway-tls
   namespace: traefik
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "172.31.1.34"
 spec:
   gatewayClassName: traefik
   listeners:

--- a/apps/traefik/values.yaml
+++ b/apps/traefik/values.yaml
@@ -10,6 +10,8 @@ traefik:
     kubernetesGateway:
       enabled: true
       namespacePolicy: All
+      annotations:
+        external-dns.alpha.kubernetes.io/target: "172.31.1.34"
   ports:
     metrics:
       expose:


### PR DESCRIPTION
Traefik v3.0 experimental Gateway provider does not populate Gateway status.addresses, so external-dns gateway-httproute source finds no target. Adding external-dns.alpha.kubernetes.io/target on both Gateways so external-dns reads it from the Gateway annotations instead of status.