### PR TITLE
external-dns: add --default-targets=172.31.1.34 for gateway-httproute…

### DIFF
--- a/apps/external-dns/values.yaml
+++ b/apps/external-dns/values.yaml
@@ -8,6 +8,9 @@ external-dns:
   provider:
     name: cloudflare
 
+  extraArgs:
+    - --default-targets=172.31.1.34
+
   env:
     - name: CF_API_TOKEN
       valueFrom:


### PR DESCRIPTION
… source

Traefik v3.0 experimental Gateway provider does not populate Gateway status.addresses so external-dns finds no targets from HTTPRoutes. DefaultTargets is used as a fallback only when a resource has no other targets, so existing ingress records are unaffected.