### PR TITLE
gateway-api-demo: fix HTTPRoute drift by adding API-defaulted fields …

### DIFF
--- a/apps/gateway-api-demo/httproute-http.yaml
+++ b/apps/gateway-api-demo/httproute-http.yaml
@@ -7,13 +7,19 @@ metadata:
   namespace: gw-api-demo
 spec:
   parentRefs:
-    - name: traefik-gateway
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
       namespace: traefik
       sectionName: web
   hostnames:
     - "gwapidemo.germanium.cz"
   rules:
-    - filters:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
         - type: RequestRedirect
           requestRedirect:
             scheme: https

--- a/apps/gateway-api-demo/httproute-https.yaml
+++ b/apps/gateway-api-demo/httproute-https.yaml
@@ -4,9 +4,6 @@
 # Routes:
 #   gwapidemo.germanium.cz/api/*  →  rewritten to /*  →  whoami  (URLRewrite filter)
 #   gwapidemo.germanium.cz/*      →  direct            →  whoami
-#
-# The whoami app echoes request details, so the path rewrite is clearly visible:
-# hitting /api/foo arrives at whoami as /foo.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -14,7 +11,9 @@ metadata:
   namespace: gw-api-demo
 spec:
   parentRefs:
-    - name: traefik-gateway-tls
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway-tls
       namespace: traefik
       sectionName: websecure
   hostnames:
@@ -32,13 +31,19 @@ spec:
               type: ReplacePrefixMatch
               replacePrefixMatch: /
       backendRefs:
-        - name: whoami
+        - group: ""
+          kind: Service
+          name: whoami
           port: 80
+          weight: 1
     # Default: route everything else directly
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: whoami
+        - group: ""
+          kind: Service
+          name: whoami
           port: 80
+          weight: 1


### PR DESCRIPTION
…explicitly

ArgoCD detects OutOfSync because the API server adds default values after apply:
- parentRefs: group/kind defaulted to gateway.networking.k8s.io/Gateway
- backendRefs: group/kind/weight defaulted to ''/Service/1
- redirect rule: matches defaulted to PathPrefix /

Adding these fields explicitly so desired state matches live state.