### PR TITLE
external-dns: revert default-targets, add crd source + DNSEndpoint fo…

### DIFF
--- a/apps/external-dns/values.yaml
+++ b/apps/external-dns/values.yaml
@@ -2,14 +2,12 @@ external-dns:
   sources:
     - ingress
     - gateway-httproute
+    - crd
 
   policy: sync
 
   provider:
     name: cloudflare
-
-  extraArgs:
-    - --default-targets=172.31.1.34
 
   env:
     - name: CF_API_TOKEN

--- a/apps/gateway-api-demo/dnsendpoint.yaml
+++ b/apps/gateway-api-demo/dnsendpoint.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: gwapidemo
+  namespace: gw-api-demo
+spec:
+  endpoints:
+    - dnsName: gwapidemo.germanium.cz
+      recordType: A
+      recordTTL: 180
+      targets:
+        - 172.31.1.34


### PR DESCRIPTION
…r demo

--default-targets broke existing proxied Cloudflare records (homeassist, n8n) because private IPs are not allowed as targets for proxied records.

Instead:
- Add crd source so external-dns reads DNSEndpoint resources
- Add explicit DNSEndpoint for gwapidemo.germanium.cz in gw-api-demo namespace with target 172.31.1.34 (Traefik LB IP)