### PR TITLE
cert-manager: add Grafana dashboard; fix kube-prometheus-stack CRD drift

### DIFF
--- a/apps/cert-manager/addons/grafana-dashboard.yaml
+++ b/apps/cert-manager/addons/grafana-dashboard.yaml
@@ -1,0 +1,694 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-cert-manager
+  namespace: cert-manager
+  labels:
+    grafana_dashboard: "1"
+data:
+  cert-manager.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "cert-manager certificate management — expiry, lifecycle, renewal and controller health",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "title": "Total Certificates",
+          "type": "stat",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "count(certmanager_certificate_expiration_timestamp_seconds)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "title": "Ready",
+          "type": "stat",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "count(certmanager_certificate_ready_status{condition=\"True\"} == 1)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+          "id": 3,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "title": "Not Ready",
+          "type": "stat",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "count(certmanager_certificate_ready_status{condition=\"False\"} == 1) OR vector(0)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+          "id": 4,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "title": "Expiring ≤ 30 Days",
+          "type": "stat",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "count((certmanager_certificate_expiration_timestamp_seconds - time()) < 86400 * 30) OR vector(0)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 4},
+          "id": 5,
+          "title": "Certificate Status",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {"type": "auto"},
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+            },
+            "overrides": [
+              {
+                "matcher": {"id": "byName", "options": "Expiry Date"},
+                "properties": [
+                  {"id": "unit", "value": "dateTimeAsLocal"},
+                  {"id": "custom.width", "value": 200}
+                ]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Days Remaining"},
+                "properties": [
+                  {"id": "unit", "value": "d"},
+                  {"id": "decimals", "value": 1},
+                  {"id": "custom.width", "value": 150},
+                  {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+                  {"id": "thresholds", "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {"color": "red", "value": null},
+                      {"color": "orange", "value": 7},
+                      {"color": "yellow", "value": 30},
+                      {"color": "green", "value": 60}
+                    ]
+                  }}
+                ]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Certificate"},
+                "properties": [{"id": "custom.width", "value": 260}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Namespace"},
+                "properties": [{"id": "custom.width", "value": 120}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Issuer"},
+                "properties": [{"id": "custom.width", "value": 160}]
+              }
+            ]
+          },
+          "gridPos": {"h": 10, "w": 24, "x": 0, "y": 5},
+          "id": 6,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false},
+            "showHeader": true,
+            "sortBy": [{"desc": false, "displayName": "Days Remaining"}]
+          },
+          "title": "Certificate Expiration",
+          "transformations": [
+            {"id": "merge", "options": {}},
+            {"id": "labelsToFields", "options": {"mode": "columns", "valueLabel": ""}},
+            {
+              "id": "filterFieldsByName",
+              "options": {"include": {"names": ["name", "namespace", "issuer_name", "Value #A", "Value #B"]}}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "renameByName": {
+                  "Value #A": "Expiry Date",
+                  "Value #B": "Days Remaining",
+                  "name": "Certificate",
+                  "namespace": "Namespace",
+                  "issuer_name": "Issuer"
+                },
+                "indexByName": {
+                  "Certificate": 0,
+                  "Namespace": 1,
+                  "Issuer": 2,
+                  "Expiry Date": 3,
+                  "Days Remaining": 4
+                }
+              }
+            }
+          ],
+          "type": "table",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "certmanager_certificate_expiration_timestamp_seconds * 1000",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "(certmanager_certificate_expiration_timestamp_seconds - time()) / 86400",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 15},
+          "id": 7,
+          "title": "Certificate Lifecycle",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {"type": "auto"},
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+            },
+            "overrides": [
+              {
+                "matcher": {"id": "byName", "options": "Issued"},
+                "properties": [
+                  {"id": "unit", "value": "dateTimeAsLocal"},
+                  {"id": "custom.width", "value": 200}
+                ]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Renewal After"},
+                "properties": [
+                  {"id": "unit", "value": "dateTimeAsLocal"},
+                  {"id": "custom.width", "value": 200}
+                ]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Expires"},
+                "properties": [
+                  {"id": "unit", "value": "dateTimeAsLocal"},
+                  {"id": "custom.width", "value": 200}
+                ]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Certificate"},
+                "properties": [{"id": "custom.width", "value": 260}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Namespace"},
+                "properties": [{"id": "custom.width", "value": 120}]
+              },
+              {
+                "matcher": {"id": "byName", "options": "Issuer"},
+                "properties": [{"id": "custom.width", "value": 160}]
+              }
+            ]
+          },
+          "gridPos": {"h": 10, "w": 24, "x": 0, "y": 16},
+          "id": 8,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false},
+            "showHeader": true,
+            "sortBy": [{"desc": false, "displayName": "Certificate"}]
+          },
+          "title": "Certificate Lifecycle (Issue → Renewal → Expiry)",
+          "transformations": [
+            {"id": "merge", "options": {}},
+            {"id": "labelsToFields", "options": {"mode": "columns", "valueLabel": ""}},
+            {
+              "id": "filterFieldsByName",
+              "options": {"include": {"names": ["name", "namespace", "issuer_name", "Value #A", "Value #B", "Value #C"]}}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "renameByName": {
+                  "Value #A": "Issued",
+                  "Value #B": "Renewal After",
+                  "Value #C": "Expires",
+                  "name": "Certificate",
+                  "namespace": "Namespace",
+                  "issuer_name": "Issuer"
+                },
+                "indexByName": {
+                  "Certificate": 0,
+                  "Namespace": 1,
+                  "Issuer": 2,
+                  "Issued": 3,
+                  "Renewal After": 4,
+                  "Expires": 5
+                }
+              }
+            }
+          ],
+          "type": "table",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "certmanager_certificate_not_before_timestamp_seconds * 1000",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "certmanager_certificate_renewal_timestamp_seconds * 1000",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "B"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "certmanager_certificate_expiration_timestamp_seconds * 1000",
+              "instant": true,
+              "range": false,
+              "legendFormat": "",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 26},
+          "id": 9,
+          "title": "Issuer Health",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [
+                {
+                  "options": {
+                    "0": {"color": "red", "index": 0, "text": "Not Ready"},
+                    "1": {"color": "green", "index": 1, "text": "Ready"}
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 5, "w": 24, "x": 0, "y": 27},
+          "id": 10,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "horizontal",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "value_and_name"
+          },
+          "title": "ClusterIssuer Status",
+          "type": "stat",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "certmanager_clusterissuer_ready_status",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{issuer_name}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+          "id": 11,
+          "title": "Controller Activity",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {"type": "linear"},
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {"group": "A", "mode": "none"},
+                "thresholdsStyle": {"mode": "off"}
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 33},
+          "id": 12,
+          "options": {
+            "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "none"}
+          },
+          "title": "Controller Sync Rate",
+          "type": "timeseries",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "rate(certmanager_controller_sync_call_count[5m])",
+              "instant": false,
+              "range": true,
+              "legendFormat": "{{controller}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {"type": "linear"},
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {"group": "A", "mode": "none"},
+                "thresholdsStyle": {"mode": "off"}
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 33},
+          "id": 13,
+          "options": {
+            "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "none"}
+          },
+          "title": "Controller Sync Errors",
+          "type": "timeseries",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "rate(certmanager_controller_sync_error_count[5m])",
+              "instant": false,
+              "range": true,
+              "legendFormat": "{{controller}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 42},
+          "id": 14,
+          "title": "ACME HTTP Activity",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {"type": "linear"},
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {"group": "A", "mode": "none"},
+                "thresholdsStyle": {"mode": "off"}
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 43},
+          "id": 15,
+          "options": {
+            "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "none"}
+          },
+          "title": "ACME Request Rate (Let’s Encrypt)",
+          "type": "timeseries",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "rate(certmanager_acme_client_request_count[5m])",
+              "instant": false,
+              "range": true,
+              "legendFormat": "{{method}} {{status}} ({{action}})",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "rate(certmanager_http_acme_client_request_count[5m])",
+              "instant": false,
+              "range": true,
+              "legendFormat": "{{method}} {{status}} {{path}}",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {"type": "linear"},
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {"group": "A", "mode": "none"},
+                "thresholdsStyle": {"mode": "off"}
+              },
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 43},
+          "id": 16,
+          "options": {
+            "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "none"}
+          },
+          "title": "ACME Request Latency (avg)",
+          "type": "timeseries",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "rate(certmanager_acme_client_request_duration_seconds_sum[5m]) / rate(certmanager_acme_client_request_duration_seconds_count[5m])",
+              "instant": false,
+              "range": true,
+              "legendFormat": "{{method}} {{action}} ({{host}})",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "rate(certmanager_http_acme_client_request_duration_seconds_sum[5m]) / rate(certmanager_http_acme_client_request_duration_seconds_count[5m])",
+              "instant": false,
+              "range": true,
+              "legendFormat": "{{method}} {{path}} ({{host}})",
+              "refId": "B"
+            }
+          ]
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 38,
+      "tags": ["cert-manager", "certificates", "tls"],
+      "templating": {"list": []},
+      "time": {"from": "now-6h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "cert-manager",
+      "uid": "certmanager-overview",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/apps/kube-prometheus-stack/application.yaml
+++ b/apps/kube-prometheus-stack/application.yaml
@@ -22,7 +22,16 @@ spec:
     path: apps/kube-prometheus-stack
     repoURL: https://github.com/germanium-git/argocd
     targetRevision: HEAD
+  ignoreDifferences:
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    jsonPointers:
+    - /status
+    jqPathExpressions:
+    - .spec.versions[].selectableFields
+
   syncPolicy:
     syncOptions:
     - CreateNamespace=true
     - ServerSideApply=true
+    - RespectIgnoreDifferences=true


### PR DESCRIPTION
- Add grafana-dashboard.yaml ConfigMap (cert-manager ns, label grafana_dashboard=1) with 6-section dashboard: summary stats, expiration table, lifecycle table, issuer health, controller activity, ACME HTTP metrics
- kube-prometheus-stack: add ignoreDifferences for CRD /status and selectableFields drift (same pattern as cert-manager fix)