### PR TITLE
fix: redirect bitnami subchart images to registry.bitnami.com

### DIFF
--- a/apps/paperless/values.yaml
+++ b/apps/paperless/values.yaml
@@ -1,4 +1,7 @@
 paperless-ngx:
+  global:
+    imageRegistry: registry.bitnami.com
+
   env:
     TZ: Europe/Prague
     PAPERLESS_ADMIN_USER: admin


### PR DESCRIPTION
Bitnami removed old image tags from Docker Hub. Setting global.imageRegistry forces postgresql and redis subcharts to pull from registry.bitnami.com.