### PR TITLE
fix: allow bitnami images from registry.bitnami.com

### DIFF
--- a/apps/paperless/values.yaml
+++ b/apps/paperless/values.yaml
@@ -1,6 +1,8 @@
 paperless-ngx:
   global:
     imageRegistry: registry.bitnami.com
+    security:
+      allowInsecureImages: true
 
   env:
     TZ: Europe/Prague


### PR DESCRIPTION
Newer bitnami charts block non-default registries without this flag. See https://github.com/bitnami/charts/issues/30850