### PR TITLE
fix: replace bitnami subcharts with standalone postgres/redis deploym…

### DIFF
--- a/apps/paperless/addons/postgresql.yaml
+++ b/apps/paperless/addons/postgresql.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: paperless-postgres
+  namespace: paperless
+spec:
+  serviceName: paperless-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: paperless-postgres
+  template:
+    metadata:
+      labels:
+        app: paperless-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_DB
+              value: paperless
+            - name: POSTGRES_USER
+              value: paperless
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-postgresql
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: nfs-atlas
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-postgres
+  namespace: paperless
+spec:
+  selector:
+    app: paperless-postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/apps/paperless/addons/redis.yaml
+++ b/apps/paperless/addons/redis.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless-redis
+  namespace: paperless
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: paperless-redis
+  template:
+    metadata:
+      labels:
+        app: paperless-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-redis
+  namespace: paperless
+spec:
+  selector:
+    app: paperless-redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/apps/paperless/values.yaml
+++ b/apps/paperless/values.yaml
@@ -1,12 +1,16 @@
 paperless-ngx:
-  global:
-    imageRegistry: registry.bitnami.com
-    security:
-      allowInsecureImages: true
-
   env:
     TZ: Europe/Prague
     PAPERLESS_ADMIN_USER: admin
+    PAPERLESS_DBHOST: paperless-postgres
+    PAPERLESS_DBNAME: paperless
+    PAPERLESS_DBUSER: paperless
+    PAPERLESS_DBPASS:
+      valueFrom:
+        secretKeyRef:
+          name: paperless-postgresql
+          key: password
+    PAPERLESS_REDIS: redis://paperless-redis:6379
 
   envFrom:
     - secretRef:
@@ -52,19 +56,7 @@ paperless-ngx:
       size: 5Gi
 
   postgresql:
-    enabled: true
-    auth:
-      existingSecret: paperless-postgresql
-      username: paperless
-      database: paperless
-    primary:
-      persistence:
-        enabled: true
-        storageClass: nfs-atlas
-        size: 5Gi
+    enabled: false
 
   redis:
-    enabled: true
-    master:
-      persistence:
-        enabled: false
+    enabled: false


### PR DESCRIPTION
…ents

Bitnami has removed old versioned tags from Docker Hub and registry.bitnami.com does not resolve from the cluster. Switch to official postgres:16-alpine and redis:7-alpine images deployed as plain K8s resources in the addons directory.