### PR TITLE
fix: use frrk8s backend for BGP (default in metallb 0.16.1)

### DIFF
--- a/apps/metallb/values.yaml
+++ b/apps/metallb/values.yaml
@@ -2,7 +2,7 @@ metallb:
   speaker:
     logLevel: warn
     frr:
-      enabled: true
+      enabled: false
 
   controller:
     logLevel: warn


### PR DESCRIPTION
frr mode is deprecated and mutually exclusive with frrk8s. frrk8s is enabled by default in 0.16.1 and handles BGP without any explicit opt-in.