### PR TITLE
feat: migrate home-assistant ingress to Gateway API via Cloudflare tu…

### DIFF
--- a/apps/home-assistant/Chart.yaml
+++ b/apps/home-assistant/Chart.yaml
@@ -3,9 +3,9 @@ name: umbrella-chart
 description: An Umbrella Helm Chart
 type: application
 version: 0.1.0
-appVersion: "2025.11.3"
+appVersion: "2026.7.1"
 
 dependencies:
   - name: home-assistant
-    version: 0.3.32
+    version: 0.3.69
     repository:  http://pajikos.github.io/home-assistant-helm-chart/

--- a/apps/home-assistant/readme.md
+++ b/apps/home-assistant/readme.md
@@ -9,3 +9,28 @@ https://artifacthub.io/packages/helm/helm-hass/home-assistant/
 
 All values
 https://github.com/pajikos/home-assistant-helm-chart/blob/main/charts/home-assistant/values.yaml
+
+## Networking
+
+Traffic reaches this app through the Cloudflare Tunnel (`cloudflared`, namespace
+`cloudflare`), not the MetalLB IP directly — its config forwards all
+`*.germanium.cz` hostnames to Traefik's `websecure` entrypoint regardless of
+host, and DNS for `homeassist.germanium.cz` is a CNAME to the tunnel
+(`f14686c6-...cfargotunnel.com`), not `172.31.1.34`.
+
+Routing uses Gateway API via the chart's native `httpRoute` support
+(`home-assistant.httpRoute` in `values.yaml`) instead of an Ingress. The
+HTTPRoute attaches to `traefik/traefik-gateway-tls-tunnel`
+(`apps/traefik/addons/gateway-tls-tunnel.yaml`) rather than the regular
+`traefik-gateway-tls` — external-dns only reads its `target` override
+annotation from the Gateway object, never from HTTPRoute, so tunnel-routed
+apps need a Gateway carrying that tunnel target, separate from the one
+direct-IP apps (e.g. esphome) use. `traefik-gateway-tls-tunnel` is shared and
+also intended for other Cloudflare-tunneled apps (n8n, paperless) when they
+migrate off Ingress.
+
+No HTTP (port 80) redirect route is needed: `cloudflared` only forwards to
+Traefik's HTTPS entrypoint, and Cloudflare's edge already handles the
+http→https upgrade before traffic reaches the tunnel.
+
+The chart's own `ingress` is disabled (`home-assistant.ingress.enabled: false`).

--- a/apps/home-assistant/values.yaml
+++ b/apps/home-assistant/values.yaml
@@ -22,10 +22,13 @@ home-assistant:
     size: 5Gi
     storageClass: "nfs-atlas"
 
-  # Ingress settings
+  # Ingress replaced by a Gateway API HTTPRoute (below) attached to the
+  # shared traefik-gateway-tls-tunnel Gateway (see apps/traefik/addons),
+  # since DNS for this host is a CNAME to the Cloudflare Tunnel rather
+  # than the MetalLB IP.
   ingress:
     # Enable ingress for home assistant
-    enabled: true
+    enabled: false
     className: "traefik"
     labels: {}
     annotations:
@@ -41,6 +44,18 @@ home-assistant:
     - secretName: homeassist-germanium-cz-prod-tls
       hosts:
         - homeassist.germanium.cz
+
+  # Gateway API HTTPRoute settings (native chart support, replaces ingress above)
+  httpRoute:
+    enabled: true
+    annotations:
+      external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    parentRefs:
+      - name: traefik-gateway-tls-tunnel
+        namespace: traefik
+        sectionName: websecure
+    hostnames:
+      - homeassist.germanium.cz
 
   # Configuration for Home Assistant
   configuration:

--- a/apps/traefik/addons/gateway-tls-tunnel.yaml
+++ b/apps/traefik/addons/gateway-tls-tunnel.yaml
@@ -1,0 +1,31 @@
+---
+# Shared Gateway for apps reached via the Cloudflare Tunnel (cloudflared
+# forwards all *.germanium.cz traffic to Traefik's websecure entrypoint
+# regardless of hostname, see cloudflare/cloudflared ConfigMap).
+#
+# external-dns only reads the `target` override from the Gateway itself
+# (never from HTTPRoute), so apps whose DNS must point at the tunnel
+# instead of the MetalLB IP need their HTTPRoutes attached here rather
+# than to traefik-gateway-tls.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: traefik-gateway-tls-tunnel
+  namespace: traefik
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "f14686c6-e006-4076-9b65-a84d93aa2e01.cfargotunnel.com"
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: websecure
+      port: 8443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: germanium-cz-prod-tls
+            namespace: default


### PR DESCRIPTION
…nnel Gateway

Replace the Traefik Ingress with the chart's native httpRoute support, attached to a new shared Gateway (traefik-gateway-tls-tunnel) rather than the existing traefik-gateway-tls used by direct-IP apps like esphome.

home-assistant's DNS is a CNAME to a Cloudflare Tunnel (f14686c6-...cfargotunnel.com), not the MetalLB IP - external-dns only reads the target override annotation from the Gateway object, never from HTTPRoute, so tunnel-routed apps need their own Gateway carrying that target. cloudflared forwards all *.germanium.cz traffic to Traefik's websecure entrypoint regardless of hostname, so this is purely additive and doesn't affect existing routes. No HTTP redirect route is needed: Cloudflare's edge handles the http->https upgrade before traffic reaches the tunnel.

The new Gateway is intentionally shared - n8n and paperless use the same tunnel and will need it too when they're migrated off Ingress.

Also bump the home-assistant chart 0.3.32 -> 0.3.69, which added the httpRoute values support used here (values schema otherwise additive-only, verified via helm template).