### PR TITLE
feat: migrate motioneye ingress to Gateway API, enable Cloudflare rou…

### DIFF
--- a/apps/motioneye/addons/httproute-https.yaml
+++ b/apps/motioneye/addons/httproute-https.yaml
@@ -1,0 +1,36 @@
+---
+# HTTPS routing via the Cloudflare Tunnel Gateway (see
+# apps/traefik/addons/gateway-tls-tunnel.yaml). This enables Cloudflare
+# routing for motioneye.germanium.cz: external-dns will flip the existing
+# DNS-only CNAME (currently -> traefik.germanium.cz) to a proxied CNAME
+# pointing at the tunnel, since the target override lives on the Gateway
+# and the cloudflare-proxied flag lives on this HTTPRoute.
+#
+# TLS is terminated here using the shared germanium.cz wildcard cert -
+# motioneye previously had no TLS at all (HTTP-only Ingress), so this is
+# HTTPS-only going forward, same as home-assistant.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: motioneye-https
+  namespace: surveilance
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  parentRefs:
+    - name: traefik-gateway-tls-tunnel
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - motioneye.germanium.cz
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: motioneye
+          port: 80
+          weight: 1

--- a/apps/motioneye/application.yaml
+++ b/apps/motioneye/application.yaml
@@ -15,13 +15,18 @@ spec:
     namespace: surveilance
     server: https://kubernetes.default.svc
   project: default
-  source:
+  sources:
+  - repoURL: https://github.com/germanium-git/argocd
+    path: apps/motioneye
+    targetRevision: HEAD
     helm:
       valueFiles:
       - values.yaml
-    path: apps/motioneye
-    repoURL: https://github.com/germanium-git/argocd
+
+  - repoURL: https://github.com/germanium-git/argocd
+    path: apps/motioneye/addons
     targetRevision: HEAD
+
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/motioneye/readme.md
+++ b/apps/motioneye/readme.md
@@ -1,0 +1,35 @@
+# motioneye
+
+## Networking
+
+Traffic reaches this app through the Cloudflare Tunnel (`cloudflared`, namespace
+`cloudflare`), not the MetalLB IP directly. Its config forwards all
+`*.germanium.cz` hostnames to Traefik's `websecure` entrypoint regardless of
+host, so no tunnel-side configuration was needed to add this hostname.
+
+Routing uses a hand-written Gateway API HTTPRoute
+(`apps/motioneye/addons/httproute-https.yaml`, the chart has no native Gateway
+API support) attached to `traefik/traefik-gateway-tls-tunnel`
+(`apps/traefik/addons/gateway-tls-tunnel.yaml`) rather than the regular
+`traefik-gateway-tls` — external-dns only reads its `target` override
+annotation from the Gateway object, never from HTTPRoute, so tunnel-routed
+apps need a Gateway carrying that tunnel target, separate from the one
+direct-IP apps (e.g. esphome) use.
+
+Before this migration, `motioneye.germanium.cz` was a DNS-only (non-proxied)
+CNAME to `traefik.germanium.cz` (itself an A record to the MetalLB IP), and
+the Ingress served plain HTTP with no TLS at all. The HTTPRoute's
+`cloudflare-proxied` annotation makes external-dns flip that record to a
+proxied CNAME pointing at the tunnel, same as `homeassist.germanium.cz`. This
+also means motioneye is now **HTTPS-only** (TLS terminated at the shared
+Gateway using the `germanium.cz` wildcard cert) — cloudflared only forwards to
+Traefik's HTTPS entrypoint, so there is no plain-HTTP path anymore.
+
+Note: motioneye serves continuous MJPEG camera streams. Cloudflare's proxy
+has known rough edges with long-lived/streaming HTTP connections (idle
+timeouts, buffering) for external viewers going through the tunnel. LAN
+clients are unaffected since local DNS resolves this host straight to the
+origin IP, bypassing Cloudflare entirely. Worth testing live view remotely
+after cutover.
+
+The chart's own `ingress` is disabled (`motioneye.ingress.enabled: false`).

--- a/apps/motioneye/values.yaml
+++ b/apps/motioneye/values.yaml
@@ -1,4 +1,10 @@
 motioneye:
+  # Ingress replaced by a Gateway API HTTPRoute (apps/motioneye/addons),
+  # attached to the shared traefik-gateway-tls-tunnel Gateway so this app
+  # is reachable via the Cloudflare Tunnel over HTTPS.
+  ingress:
+    enabled: false
+
   storageClassName: nfs-atlas
   podSecurityContext: 
     runAsUser: 1002


### PR DESCRIPTION
…ting

Replace the plain-HTTP-only Ingress with a hand-written HTTPRoute attached to the shared traefik-gateway-tls-tunnel Gateway (the chart has no native Gateway API support), enabling Cloudflare Tunnel routing for motioneye.germanium.cz as requested.

Confirmed via public DNS lookups that motioneye.germanium.cz is currently a DNS-only CNAME to traefik.germanium.cz (itself an A record to the MetalLB IP), already owned by external-dns - the cloudflare-proxied annotation on the new HTTPRoute should make external-dns flip it to a proxied CNAME pointing at the tunnel automatically, same as homeassist.germanium.cz. No changes needed on the Cloudflare/tunnel side: cloudflared's ingress config is already a wildcard *.germanium.cz rule.

This makes motioneye HTTPS-only going forward (TLS terminated at the shared Gateway using the germanium.cz wildcard cert) since cloudflared only forwards to Traefik's HTTPS entrypoint - there was no TLS at all before. Confirmed with the user this tradeoff is acceptable.

Also fix the Application to multi-source (Helm chart + addons/ directory) so the HTTPRoute is actually delivered through Argo, same fix esphome needed.